### PR TITLE
small updates on config files for ga simulation. 

### DIFF
--- a/configs/benchmark_tests/capacity/template_ga_simulation.json
+++ b/configs/benchmark_tests/capacity/template_ga_simulation.json
@@ -15,12 +15,11 @@
                           "algorithm_configs": {
                                     "algorithm": "genetic",
                                     "hyperparameters": {
-                                                          "mutationrate": 0.1,
                                                           "epochs": 100,
                                                           "fitness_function_type": "corrsig_fit",
                                                           "seed": null,
                                                           "generange": [ [-1.2, 0.6], [-1.2, 0.6], [-1.2, 0.6], [-0.7, 0.3], [-0.7, 0.3] ],
-                                                          "partition": [5, 5, 5, 5, 5],
+                                                          "partition": [4,22],
                                                           "transformation":{
                                                                           "gene_trafo_index": null,
                                                                           "trafo_function": null


### PR DESCRIPTION
Mutationrate is legacy and not used by the code, so it is removed. Partitioning should only contain two list elements because more list elements are not well-used by the code.